### PR TITLE
Release 0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
 # CHANGELOG
 
-# v0.1 - *Initial release*
+# 0.2
+
+- refactor: store items in staging files. ([bf88f0f](https://github.com/Jxcob-R/tojo/commit/bf88f0f)) 
+- refactor: fixed width item storage ([78068e3](https://github.com/Jxcob-R/tojo/commit/78068e3)) 
+- feat: Enable ID indexation of items ([e697792](https://github.com/Jxcob-R/tojo/commit/e697792)) 
+- feat: add support to item status with work ([f8253b0](https://github.com/Jxcob-R/tojo/commit/f8253b0)) 
+- refactor(dir): store next available project item ID ([a1e0a1e](https://github.com/Jxcob-R/tojo/commit/a1e0a1e)) 
+- refactor: remove deprecated macros from tojo ([fa34adb](https://github.com/Jxcob-R/tojo/commit/fa34adb)) 
+
+# 0.1 - *Initial release*
 
 - feat: create project, add and list task items ([036888f](https://github.com/Jxcob-R/tojo/commit/036888f))
 - refactor: move project finding logic to dir ([aa8b346](https://github.com/Jxcob-R/tojo/commit/aa8b346))
 - refactor(ds): remove _item temporary struct name ([448c9d3](https://github.com/Jxcob-R/tojo/commit/448c9d3))
 - build(make): adopt ASAN developer flags ([c781d62](https://github.com/Jxcob-R/tojo/commit/c781d62))
-- docs: update commit type suggestions ([4503d20](https://github.com/Jxcob-R/tojo/commit/44503d20503d20))
+- docs: update commit type suggestions ([4503d20](https://github.com/Jxcob-R/tojo/commit/a25c2e9))

--- a/src/config.h
+++ b/src/config.h
@@ -2,7 +2,7 @@
 #define CONFIG_H
 
 /* Version as a string */
-#define CONF_VERSION "0.1"
+#define CONF_VERSION "0.2"
 
 /* Name definitions */
 #define CONF_NAME_LOWER "tojo"

--- a/src/config.h
+++ b/src/config.h
@@ -26,4 +26,8 @@
 #define RET_UNABLE_TO_INIT 5
 #define RET_NO_PROJ 6
 
+/* Directory search macros */
+#define MAX_PATH 4096
+#define MAX_PATH_LVLS 128
+
 #endif

--- a/src/dir.c
+++ b/src/dir.c
@@ -1,6 +1,5 @@
 #include "dir.h"
 #include "config.h"
-#include "tojo.h"
 #include "ds/item.h"
 
 #ifdef DEBUG
@@ -8,15 +7,15 @@
 #endif
 
 /* Project directory */
-static char proj_path[_MAX_PATH] =  { '\0' };
+static char proj_path[MAX_PATH] =  { '\0' };
 
 /* Item storage */
-static char items_path[_MAX_PATH] = { '\0' };
-static char todo_path[_MAX_PATH] =  { '\0' };
-static char ip_path[_MAX_PATH] =    { '\0' };
-static char done_path[_MAX_PATH] =  { '\0' };
+static char items_path[MAX_PATH] = { '\0' };
+static char todo_path[MAX_PATH] =  { '\0' };
+static char ip_path[MAX_PATH] =    { '\0' };
+static char done_path[MAX_PATH] =  { '\0' };
 
-static char next_id_path[_MAX_PATH] = { '\0' }; /* Next available item ID */
+static char next_id_path[MAX_PATH] = { '\0' }; /* Next available item ID */
 
 /**
  * @brief Set up global path variables to default values if not already done
@@ -32,19 +31,19 @@ static void setup_path_names(const char * const path) {
 
     /* Set up items path */
     if (!*items_path)
-        dir_construct_path(proj_path, _DIR_ITEM_PATH_D, items_path, _MAX_PATH);
+        dir_construct_path(proj_path, _DIR_ITEM_PATH_D, items_path, MAX_PATH);
 
     /* Item file names */
     if (!*todo_path)
-        dir_construct_path(items_path, _DIR_ITEM_TODO_F, todo_path, _MAX_PATH);
+        dir_construct_path(items_path, _DIR_ITEM_TODO_F, todo_path, MAX_PATH);
     if (!*ip_path)
-        dir_construct_path(items_path, _DIR_ITEM_INPROG_F, ip_path, _MAX_PATH);
+        dir_construct_path(items_path, _DIR_ITEM_INPROG_F, ip_path, MAX_PATH);
     if (!*done_path)
-        dir_construct_path(items_path, _DIR_ITEM_DONE_F, done_path, _MAX_PATH);
+        dir_construct_path(items_path, _DIR_ITEM_DONE_F, done_path, MAX_PATH);
 
     /* Next ID data */
     if (!*next_id_path)
-        dir_construct_path(proj_path, _DIR_NEXT_ID_F, next_id_path, _MAX_PATH);
+        dir_construct_path(proj_path, _DIR_NEXT_ID_F, next_id_path, MAX_PATH);
 }
 
 /**
@@ -216,13 +215,13 @@ static void build_relative_path(char *dest, int levels_up,
  */
 static int find_target_directory(const char *start_path, const char *home_dir, 
                                  const char *target_dir, int *levels_up) {
-    char search_path[_MAX_PATH];
-    char test_path[_MAX_PATH + sizeof(CONF_PROJ_DIR)];
+    char search_path[MAX_PATH];
+    char test_path[MAX_PATH + sizeof(CONF_PROJ_DIR)];
     
     strcpy(search_path, start_path);
     *levels_up = 0;
     
-    while (*levels_up < _MAX_PATH_LVLS) {
+    while (*levels_up < MAX_PATH_LVLS) {
         /* Check if we've reached the home directory (exclusive) */
         if (strcmp(search_path, home_dir) == 0) {
             return -1;
@@ -251,7 +250,7 @@ static int find_target_directory(const char *start_path, const char *home_dir,
 int dir_find_project(char *dir) {
     assert(dir);
     
-    char cwd[_MAX_PATH];
+    char cwd[MAX_PATH];
     char *home_dir;
     int levels_up;
     

--- a/src/dir.h
+++ b/src/dir.h
@@ -21,6 +21,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <pwd.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/src/ds/item.h
+++ b/src/ds/item.h
@@ -27,7 +27,7 @@ struct item {
     /*
      * Future additions
      * File or directory target name in project -- relative to project root
-    char item_target[_MAX_PATH];
+    char item_target[MAX_PATH];
      * Date and time item was last changed
     time_t item_time;
      * Priority of an item

--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,7 @@ int main(int argc, char *argv[]) {
         printf("Unknown usage of %s\n", argv[0]);
         tj_help();
 #ifdef DEBUG
-        return print_return(TJ_RET_NO_ARGS);
+        return print_return(RET_NO_ARGS);
 #else
         return RET_NO_ARGS;
 #endif

--- a/src/tojo.c
+++ b/src/tojo.c
@@ -91,7 +91,7 @@ int tj_main(const int argc, char * const argv[]) {
     }
 
     /* Find TJ project directory */
-    char proj_dir[_MAX_PATH];
+    char proj_dir[MAX_PATH];
     if (dir_find_project(proj_dir) != 0) {
 #ifdef DEBUG
         log_err("Not inside a project");

--- a/src/tojo.h
+++ b/src/tojo.h
@@ -14,29 +14,6 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
-/* Name definitions */
-#define TJ_NAME_LOWER "tojo"
-#define TJ_NAME_UPPER "TOJO"
-#define TJ_CMD_NAME "tojo"
-#define TJ_CMD_NAME_SHORTENED "tj"
-
-#define TJ_DIR_NAME ".tojo"
-
-/* Directory search macros */
-#define _MAX_PATH 4096
-#define _MAX_PATH_LVLS 128
-
-/* Version as a string */
-#define TJ_VERSION "0.0"
-
-/* GitHub and contributing */
-#define TJ_GITHUB "https://github.com/..."
-
-/* Program return codes */
-#define TJ_RET_NO_ARGS 1
-#define TJ_RET_INVALID_OPTS 2
-#define TJ_RET_INVALID_CMD 3
-
 /**
  * @brief Command struct representing a single valid command that traces to a
  * module


### PR DESCRIPTION
## Release [0.2](https://github.com/Jxcob-R/tojo/compare/tojo-0.1...release/0.2) (2025-06-09)

### Overview

- Work on items with the `work` command, specifying items with a unique `id` (use `--id` or `-i` flag with item ID)
    - Items being worked on are 'in progress' and appear separately in the item list
- Improve item storage and I/O performance with fixed-width item entries

### Changes
- refactor: store items in staging files. ([bf88f0f](https://github.com/Jxcob-R/tojo/commit/bf88f0f)) 
- refactor: fixed width item storage ([78068e3](https://github.com/Jxcob-R/tojo/commit/78068e3)) 
- feat: Enable ID indexation of items ([e697792](https://github.com/Jxcob-R/tojo/commit/e697792)) 
- feat: add support to item status with work ([f8253b0](https://github.com/Jxcob-R/tojo/commit/f8253b0)) 
- refactor(dir): store next available project item ID ([a1e0a1e](https://github.com/Jxcob-R/tojo/commit/a1e0a1e)) 
- refactor: remove deprecated macros from tojo ([fa34adb](https://github.com/Jxcob-R/tojo/commit/fa34adb)) 
