### PR TITLE
Release 0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+# 0.3
+
+- feat(cmds): Add resolve 'res' command to mark items as done ([1e263f1](https://github.com/Jxcob-R/tojo/commit/1e263f1))
+- refactor(dir): abstract opening of status item file descriptors ([8721f3b](https://github.com/Jxcob-R/tojo/commit/8721f3b))
+- feat: order items in project with respect to their status ([a73e260](https://github.com/Jxcob-R/tojo/commit/a73e260))
+- docs: document command functionality in help pages ([3bd758a](https://github.com/Jxcob-R/tojo/commit/3bd758a))
+- fix(cmds): interpret user input as base 10 correctly ([81e55e8](https://github.com/Jxcob-R/tojo/commit/81e55e8))
+- feat(cmds): add item restaging as add command flag ([6e789e0](https://github.com/Jxcob-R/tojo/commit/6e789e0))
+- refactor: add typedef for item ID type ([d0abbe6](https://github.com/Jxcob-R/tojo/commit/d0abbe6))
+
 # 0.2
 
 - refactor: store items in staging files. ([bf88f0f](https://github.com/Jxcob-R/tojo/commit/bf88f0f)) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 # 0.3
 
 - feat(cmds): Add resolve 'res' command to mark items as done ([1e263f1](https://github.com/Jxcob-R/tojo/commit/1e263f1))
-- refactor(dir): abstract opening of status item file descriptors ([8721f3b](https://github.com/Jxcob-R/tojo/commit/8721f3b))
-- feat: order items in project with respect to their status ([a73e260](https://github.com/Jxcob-R/tojo/commit/a73e260))
-- docs: document command functionality in help pages ([3bd758a](https://github.com/Jxcob-R/tojo/commit/3bd758a))
-- fix(cmds): interpret user input as base 10 correctly ([81e55e8](https://github.com/Jxcob-R/tojo/commit/81e55e8))
-- feat(cmds): add item restaging as add command flag ([6e789e0](https://github.com/Jxcob-R/tojo/commit/6e789e0))
 - refactor: add typedef for item ID type ([d0abbe6](https://github.com/Jxcob-R/tojo/commit/d0abbe6))
+- feat(cmds): add item restaging as add command flag ([6e789e0](https://github.com/Jxcob-R/tojo/commit/6e789e0))
+- fix(cmds): interpret user input as base 10 correctly ([81e55e8](https://github.com/Jxcob-R/tojo/commit/81e55e8))
+- docs: document command functionality in help pages ([3bd758a](https://github.com/Jxcob-R/tojo/commit/3bd758a))
+- feat: order items in project with respect to their status ([a73e260](https://github.com/Jxcob-R/tojo/commit/a73e260))
+- refactor(dir): abstract opening of status item file descriptors ([8721f3b](https://github.com/Jxcob-R/tojo/commit/8721f3b))
 
 # 0.2
 

--- a/src/config.h
+++ b/src/config.h
@@ -2,7 +2,7 @@
 #define CONFIG_H
 
 /* Version as a string */
-#define CONF_VERSION "0.2"
+#define CONF_VERSION "0.3"
 
 /* Name definitions */
 #define CONF_NAME_LOWER "tojo"

--- a/src/ds/item.h
+++ b/src/ds/item.h
@@ -13,7 +13,7 @@
 /**
  * Signed item ID type
  */
-typedef int32_t sitem_id; // TODO: Change to signed 32-bit (?) int type
+typedef int32_t sitem_id;
 
 typedef struct item item;
 


### PR DESCRIPTION
## Release [0.3](https://github.com/Jxcob-R/tojo/compare/tojo-0.2...release/0.3) (2025-06-19)

### Overview

- Mark items as 'done' with the `res` (i.e. "resolve") command
    - Example usage: `tojo res -i 0` resolves item with ID `0`
    - More related utility planned
- Interface with base-10 item IDs fixed and user-input properly handled (fixed a bug)
- Items are now displayed in order of IDs

### Changes

- feat(cmds): Add resolve 'res' command to mark items as done ([1e263f1](https://github.com/Jxcob-R/tojo/commit/1e263f1))
- refactor: add typedef for item ID type ([d0abbe6](https://github.com/Jxcob-R/tojo/commit/d0abbe6))
- feat(cmds): add item restaging as add command flag ([6e789e0](https://github.com/Jxcob-R/tojo/commit/6e789e0))
- fix(cmds): interpret user input as base 10 correctly ([81e55e8](https://github.com/Jxcob-R/tojo/commit/81e55e8))
- docs: document command functionality in help pages ([3bd758a](https://github.com/Jxcob-R/tojo/commit/3bd758a))
- feat: order items in project with respect to their status ([a73e260](https://github.com/Jxcob-R/tojo/commit/a73e260))
- refactor(dir): abstract opening of status item file descriptors ([8721f3b](https://github.com/Jxcob-R/tojo/commit/8721f3b))