### PR TITLE
Release 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+# 0.4
+
+- compat: use isatty to modify pretty (coloured) print behaviour ([0b59be4](https://github.com/Jxcob-R/tojo/commit/0b59be4))
+- chore: add NDEBUG flag to final build ([02e3fa7](https://github.com/Jxcob-R/tojo/commit/02e3fa7))
+- feat: item codes and prefixes ([025c430](https://github.com/Jxcob-R/tojo/commit/025c430))
+- refactor: clear trailing and leading whitespace in item names ([3b5707a](https://github.com/Jxcob-R/tojo/commit/3b5707a))
+- feat: set defaults for subcommands ([a3819fc](https://github.com/Jxcob-R/tojo/commit/a3819fc))
+- docs: update README with guide and overview ([af8f8e8](https://github.com/Jxcob-R/tojo/commit/af8f8e8))
+
 # 0.3
 
 - feat(cmds): Add resolve 'res' command to mark items as done ([1e263f1](https://github.com/Jxcob-R/tojo/commit/1e263f1))

--- a/src/config.h
+++ b/src/config.h
@@ -2,7 +2,7 @@
 #define CONFIG_H
 
 /* Version as a string */
-#define CONF_VERSION "0.3"
+#define CONF_VERSION "0.4"
 
 /* Name definitions */
 #define CONF_NAME_LOWER "tojo"


### PR DESCRIPTION
## Release [0.4](https://github.com/Jxcob-R/tojo/compare/tojo-0.3...release/0.4) (2025-07-06)

### Overview

- Item codes as a means by which to reference task items
- Better README (finally an actual piece of documentation)
- TTY colour compatibility (and piping)

### Changes

- compat: use isatty to modify pretty (coloured) print behaviour ([0b59be4](https://github.com/Jxcob-R/tojo/commit/0b59be4))
- chore: add NDEBUG flag to final build ([02e3fa7](https://github.com/Jxcob-R/tojo/commit/02e3fa7))
- feat: item codes and prefixes ([025c430](https://github.com/Jxcob-R/tojo/commit/025c430))
- refactor: clear trailing and leading whitespace in item names ([3b5707a](https://github.com/Jxcob-R/tojo/commit/3b5707a))
- feat: set defaults for subcommands ([a3819fc](https://github.com/Jxcob-R/tojo/commit/a3819fc))
- docs: update README with guide and overview ([af8f8e8](https://github.com/Jxcob-R/tojo/commit/af8f8e8))

