### PR TITLE
Release 0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+# 0.5
+
+- fix: add missing new line to main help ([d0db1a3](https://github.com/Jxcob-R/tojo/commit/d0db1a3))
+- fix: item code generation ([8e8835c](https://github.com/Jxcob-R/tojo/commit/8e8835c))
+- (release/0.4) fix(ds): string length also checked for validating item code ([ebbc3c0](https://github.com/Jxcob-R/tojo/commit/ebbc3c0))
+- feat(cmds): list option for status view ([f54d460](https://github.com/Jxcob-R/tojo/commit/f54d460))
+- memfix: save potential NULL reference from item code ([b7993d6](https://github.com/Jxcob-R/tojo/commit/b7993d6))
+- chore: add install script ([6267709](https://github.com/Jxcob-R/tojo/commit/6267709))
+- feat(cmds): add backlog command ([300b319](https://github.com/Jxcob-R/tojo/commit/300b319))
+- refactor(cmds): improve code validation process cleanliness ([80ad0c1](https://github.com/Jxcob-R/tojo/commit/80ad0c1))
+
 # 0.4
 
 - compat: use isatty to modify pretty (coloured) print behaviour ([0b59be4](https://github.com/Jxcob-R/tojo/commit/0b59be4))

--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ locally, separate to team-based tickets (i.e., Jira or Linear).
 
 Support for GNU/Linux OS's only. Support for Mac can be introduced later.
 
-1. Clone and open project
-2. Run `make final`
-3. Put `tojo` binary in your path
+Run the `install.sh` script and specify the install path, `~/.local/bin` is used
+as the default path.
 
 ## Simple user guide
 

--- a/src/config.h
+++ b/src/config.h
@@ -2,7 +2,7 @@
 #define CONFIG_H
 
 /* Version as a string */
-#define CONF_VERSION "0.4"
+#define CONF_VERSION "0.5"
 
 /* Name definitions */
 #define CONF_NAME_LOWER "tojo"


### PR DESCRIPTION
## Release [0.5](https://github.com/Jxcob-R/tojo/compare/tojo-0.4...release/0.5) (2025-07-10)

### Overview

- Corrections to the way item codes and prefixes are generated
- Ability to backlog items
- More list options; specifying item status
- install script

### Changes

- fix: add missing new line to main help ([d0db1a3](https://github.com/Jxcob-R/tojo/commit/d0db1a3))
- fix: item code generation ([8e8835c](https://github.com/Jxcob-R/tojo/commit/8e8835c))
- (release/0.4) fix(ds): string length also checked for validating item code ([ebbc3c0](https://github.com/Jxcob-R/tojo/commit/ebbc3c0))
- feat(cmds): list option for status view ([f54d460](https://github.com/Jxcob-R/tojo/commit/f54d460))
- memfix: save potential NULL reference from item code ([b7993d6](https://github.com/Jxcob-R/tojo/commit/b7993d6))
- chore: add install script ([6267709](https://github.com/Jxcob-R/tojo/commit/6267709))
- feat(cmds): add backlog command ([300b319](https://github.com/Jxcob-R/tojo/commit/300b319))
- refactor(cmds): improve code validation process cleanliness ([80ad0c1](https://github.com/Jxcob-R/tojo/commit/80ad0c1))



